### PR TITLE
more granular nextHopProtocol cases

### DIFF
--- a/background.js
+++ b/background.js
@@ -7,12 +7,14 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.startsWith("h2")) {
     title = "HTTP/2";
     icon = "h2";
-  } else if (message.startsWith("h3")) {
-    title = "HTTP/3"
+  }
+  else if (message.startsWith("h3")) {
+    title = "HTTP/3";
     icon = "h3";
-  } else if (message.startsWith("http") {
-      title = message.toUpperCase();
-      icon = "h1";
+  }
+  else if (message.startsWith("http") {
+    title = message.toUpperCase();
+    icon = "h1";
   }
   else {
     continue;

--- a/background.js
+++ b/background.js
@@ -10,12 +10,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   } else if (message.startsWith("h3")) {
     title = "HTTP/3"
     icon = "h3";
-  } else if (message.startsWith("http/") {
-    if (message === "http/1.1")
-      title = "HTTP/1.1"
-    else if (message === "http/1.0")
-      title = "HTTP/1.0"
-    icon = "h1"
+  } else if (message.startsWith("http") {
+      title = message.toUpperCase();
+      icon = "h1";
   }
   else {
     continue;

--- a/background.js
+++ b/background.js
@@ -8,7 +8,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     title = "HTTP/2";
     icon = "h2";
   }
-  else if (message.startsWith("h3")) {
+  else if (message === "h3") {
     title = "HTTP/3";
     icon = "h3";
   }

--- a/background.js
+++ b/background.js
@@ -12,7 +12,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     title = "HTTP/3";
     icon = "h3";
   }
-  else if (message.startsWith("http") {
+  else if (message.startsWith("http")) {
     title = message.toUpperCase();
     icon = "h1";
   }

--- a/background.js
+++ b/background.js
@@ -16,9 +16,6 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     title = message.toUpperCase();
     icon = "h1";
   }
-  else {
-    continue;
-  }
 
   browser.pageAction.setIcon({ path: "icons/" + icon + ".png", tabId });
   browser.pageAction.setTitle({ tabId, title });

--- a/background.js
+++ b/background.js
@@ -1,16 +1,24 @@
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   const tabId = sender.tab.id;
   let title = message;
-  let icon;
+  let icon = "default";
 
-  if (message === "h2") {
+  // https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/nextHopProtocol#value
+  if (message.startsWith("h2")) {
     title = "HTTP/2";
     icon = "h2";
   } else if (message.startsWith("h3")) {
     title = "HTTP/3"
     icon = "h3";
-  } else {
-    icon = "h1";
+  } else if (message.startsWith("http/") {
+    if (message === "http/1.1")
+      title = "HTTP/1.1"
+    else if (message === "http/1.0")
+      title = "HTTP/1.0"
+    icon = "h1"
+  }
+  else {
+    continue;
   }
 
   browser.pageAction.setIcon({ path: "icons/" + icon + ".png", tabId });


### PR DESCRIPTION
handle http/1.x explicitly, separate from empty protocol value
it seems some http/1.1 sites return a blank nextHopProtocol, but the official 1.1 value is `http/1.1`:

https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/nextHopProtocol#value

[NO_TRAIN]::